### PR TITLE
Make while/for loop examples more consistent

### DIFF
--- a/source/PvL_03.rst
+++ b/source/PvL_03.rst
@@ -1223,7 +1223,7 @@ You can almost read the ``while`` statement as if it were English. It means,
 while ``i`` is less than or equal to ``n``, continue executing the body of the loop. Within
 the body, each time, increment ``i``. When ``i`` passes ``n``, return your accumulated sum.
 In other words: while <CONDITION> is True, <STATEMENT> is executed.
-Of course, this example could be written more concisely as ``sum(range(n + 1))`` because the function ``sum`` already exists. 
+Of course, this example could be written more concisely as ``sum(range(1, n + 1))`` because the function ``sum`` already exists. 
 
 More formally, here is precise flow of execution for a ``while`` statement:
 
@@ -1260,13 +1260,15 @@ terminates.  By comparison, here is an equivalent snippet that uses ``for`` inst
         n = 6
 
         current_sum  = 0
-        for i in range(n+1):
+        for i in range(1, n+1):
             current_sum += i
         print(current_sum)
 
 Notice the slightly tricky call to the ``range`` function --- we had to add one onto ``n``, 
 because ``range`` generates its list up to but excluding the value you give it.  
-It would be easy to make a programming mistake and overlook this.   
+It would be easy to make a programming mistake and overlook this. Also, just like in the
+``while`` example above, we instruct ``range`` to start at ``1`` because in this particular
+case we can skip the addition when ``i`` is zero. 
         
 So why have two kinds of loop if ``for`` looks easier?  This next example shows a case where
 we need the extra power that we get from the ``while`` loop.

--- a/source/PvL_03.rst
+++ b/source/PvL_03.rst
@@ -1212,7 +1212,7 @@ Here is a fragment of code that demonstrates the use of the ``while`` statement:
         n = 6
     
         current_sum  = 0
-        i = 1
+        i = 0
         while i <= n:
             current_sum += i
             i += 1
@@ -1223,7 +1223,7 @@ You can almost read the ``while`` statement as if it were English. It means,
 while ``i`` is less than or equal to ``n``, continue executing the body of the loop. Within
 the body, each time, increment ``i``. When ``i`` passes ``n``, return your accumulated sum.
 In other words: while <CONDITION> is True, <STATEMENT> is executed.
-Of course, this example could be written more concisely as ``sum(range(1, n + 1))`` because the function ``sum`` already exists. 
+Of course, this example could be written more concisely as ``sum(range(n + 1))`` because the function ``sum`` already exists. 
 
 More formally, here is precise flow of execution for a ``while`` statement:
 
@@ -1245,8 +1245,8 @@ loop will repeat forever, which is called an **infinite loop**.
 In the case here, we can prove that the loop terminates because we
 know that the value of ``n`` is finite, and we can see that the value of ``i``
 increments each time through the loop, so eventually it will have to exceed ``n``. In
-other cases, it is not so easy, even impossible in some cases, 
-to tell if the loop will ever terminate.  
+other cases it is not so easy, maybe even impossible, to tell if the loop will ever
+terminate.  
 
 What you will notice here is that the ``while`` loop is more work for
 you --- the programmer --- than the equivalent ``for`` loop.  When using a ``while``
@@ -1260,15 +1260,13 @@ terminates.  By comparison, here is an equivalent snippet that uses ``for`` inst
         n = 6
 
         current_sum  = 0
-        for i in range(1, n+1):
+        for i in range(n+1):
             current_sum += i
         print(current_sum)
 
 Notice the slightly tricky call to the ``range`` function --- we had to add one onto ``n``, 
 because ``range`` generates its list up to but excluding the value you give it.  
-It would be easy to make a programming mistake and overlook this. Also, just like in the
-``while`` example above, we instruct ``range`` to start at ``1`` because in this particular
-case we can skip the addition when ``i`` is zero. 
+It would be easy to make a programming mistake and overlook this. 
         
 So why have two kinds of loop if ``for`` looks easier?  This next example shows a case where
 we need the extra power that we get from the ``while`` loop.


### PR DESCRIPTION
The `while` example sums integers from 1 up to, and including, `n`. The simplified `for i in range(n+1)` that we give as the better alternative has the same outcome, but is slightly different in that the loop is traversed also for `i = 0`.

Since we say the behavior is exactly the same it's best to have the `range` alternative also skip the zero case. This was, rightly, confusing a student who was tracing the behavior of each loop cycle-by-cycle.